### PR TITLE
feat: DRY toolchain definition

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//:lib/json.bzl", "json_bzl")
+
+# We only use bazel_skylib for the unittest to exercise the yq binary pulled as a toolchain.  Note,
+# there are better ways to yq() a thing; YQ being a common tool, it's fairly reliable to use it
+# here, plus there should be fairly frequent updates
 
 http_archive(
     name = "bazel_skylib",
@@ -13,37 +18,43 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+# ==========================
 # toolchains
 
-http_archive(
-    name = "yq_darwin_amd64",
-    # The BUILD file is really a few convenience aliases (may remove later, or convert to list)
-    # You can test whether it's resolving for your architecture using:
+# generates a virtual repository with:
+# file: @versions_yq//:json.bzl defining YQ object that wraps attachments.json as a bazel dict
+# file: @versions_yq//:BUILD defining register_toolchains()
+json_bzl(
+    name = "versions_yq",
+    bzl_object = "YQ",
+    json = "//toolchains/yq:attachments.json",
+)
 
+# This repo doesn't actually exist, but is created by json_bzl() above
+
+load("@versions_yq//:json.bzl", "YQ", yq_register = "register_toolchains")
+
+# now create an import definition of the repos defined by json_bzl() from attachments.json
+# of course, they won't be read unless they're called in by dependency, and the http static
+# resource/blob will cache in a basic HTTP(S)_PROXY cache or a bazel cache service
+#
+# we cannot easily scaffold/template this as the `build_file_content` is fairly variable
+
+[http_archive(
+    name = k,
+    # NOTE: this generates the alias exploited in //toolchains/yq/BUILD.bazel: `tool = "@{}//:yq"`
     #     bazel run @yq_darwin_amd64//:yq -- --version
+    #     bazel run @yq_darwin_arm64//:yq -- --version
     build_file_content = "\n".join([
-        """alias(name="yq", actual="//:yq_darwin_amd64", visibility = ["//visibility:public"])""",
+        """alias(name="yq", actual="//:{}", visibility = ["//visibility:public"])""".format(k),
         "",  # readability during debug
     ]),
-    sha256 = "52dd4639d5aa9dda525346dd74efbc0f017d000b1570b8fa5c8f983420359ef9",
-    urls = [
-        "https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_darwin_amd64.tar.gz",
-    ],
-)
+    sha256 = v["sha256"],
+    url = v["url"],
+) for k, v in YQ.items()]
 
-http_archive(
-    name = "yq_darwin_arm64",
-    build_file_content = "\n".join([
-        """alias(name="yq", actual="//:yq_darwin_arm64", visibility = ["//visibility:public"])""",
-        "",  # readability during debug
-    ]),
-    sha256 = "47d5867c705cc04cb34ae7349b18ac03f1c2d2589da650e3cc57bcf865ee3411",
-    urls = [
-        "https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_darwin_arm64.tar.gz",
-    ],
-)
+# json_bzl() creates a toolchain registration func based on the keys of the attachments.json file.
+# The same naming -- the key of the dict is used as the name of the repository -- is used in
+# //toolchains/yq:BUILD
 
-register_toolchains(
-    "//toolchains/yq:yq_darwin_amd64_toolchain",
-    "//toolchains/yq:yq_darwin_arm64_toolchain",
-)
+yq_register()

--- a/lib/json.bzl
+++ b/lib/json.bzl
@@ -1,0 +1,31 @@
+def json_bzl_impl(repository_ctx):
+    data = json.decode(repository_ctx.read(repository_ctx.path(repository_ctx.attr.json)))
+    base = repository_ctx.attr.toolchain_base
+
+    config_lines = [
+        "# {} construct based on contents of {}".format(repository_ctx.attr.bzl_object, repository_ctx.attr.json),
+        "",
+        "{} = {}".format(repository_ctx.attr.bzl_object, data),
+        "",
+        "def register_toolchains():",
+        "    native.register_toolchains(",
+    ] + [
+        """        "{}:{}_toolchain",""".format(base, k)
+        for k in data.keys()
+    ] + [
+        "    )",
+        "",
+    ]
+
+    repository_ctx.file(repository_ctx.attr.bzl_name, "\n".join(config_lines))
+    repository_ctx.file("BUILD", "")
+
+json_bzl = repository_rule(
+    attrs = {
+        "json": attr.label(mandatory = True),
+        "bzl_name": attr.string(default = "json.bzl"),
+        "bzl_object": attr.string(default = "JSON"),
+        "toolchain_base": attr.string(default = "@//toolchains/yq"),
+    },
+    implementation = json_bzl_impl,
+)

--- a/toolchains/yq/BUILD.bazel
+++ b/toolchains/yq/BUILD.bazel
@@ -1,4 +1,5 @@
 load(":yq_toolchain.bzl", "yq_toolchain")  # load the rule()
+load("@versions_yq//:json.bzl", "YQ")  # generated in WORKSPACE from attachments.json
 
 # define a specific type to trigger type-checking
 toolchain_type(
@@ -6,54 +7,37 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
-yq_toolchain(
-    name = "yq_darwin_amd64",  # local scope doesn't clash with @yq_darwin_amd64
+[
+    yq_toolchain(
+        name = "{}".format(k),
 
-    # tool matches the `bazel run @yq_darwin_amd64//:yq -- --version` binary noted above in
-    # (WORKSPACE) `http_archive( name = "yq_darwin_amd64", ...)` with `alias( name="yq", ...)`
-    # in `build_file_content`.  Note that the alias in that content both maps the consistent `:yq`
-    # to the `:yq_darwin_amd64` arch-specific binary in each tarball archive, but also opens up
-    # visibility
-    tool = "@yq_darwin_amd64//:yq",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "yq_darwin_amd64_toolchain",
-    exec_compatible_with = [
-        "@platforms//os:osx",  # yep, "osx" not "darwin"
-        "@platforms//cpu:x86_64",  # yep, "x86_64" not "amd64"
-    ],
-    target_compatible_with = [
-        "@platforms//os:osx",
-        "@platforms//cpu:x86_64",
-    ],
-
-    # matches `yq_toolchain( name = "yq_darwin_amd64", ...` in this file
-    toolchain = ":yq_darwin_amd64",
-    toolchain_type = ":toolchain_type",  # `toolchain_type(...)` above
-)
-
-yq_toolchain(
-    name = "yq_darwin_arm64",
-    tool = "@yq_darwin_arm64//:yq",
-    visibility = ["//visibility:public"],
-)
+        # tool matches the `bazel run @yq_darwin_amd64//:yq -- --version` binary noted above in
+        # (WORKSPACE) `http_archive( name = "yq_darwin_amd64", ...)` with `alias( name="yq", ...)`
+        # in `build_file_content`.  Note that the alias in that content both maps the consistent `:yq`
+        # to the `:yq_darwin_amd64` arch-specific binary in each tarball archive, but also opens up
+        # visibility
+        tool = "@{}//:yq".format(k),
+        visibility = ["//visibility:public"],
+    )
+    for k, v in YQ.items()
+]
 
 # With https://github.com/bazelbuild/platforms/pull/67 it seems that Bazel direction seems to flop
 # back to "aarch64" and "x86_64" rather than the more consistent "amd64" and "arm64"
-toolchain(
-    name = "yq_darwin_arm64_toolchain",
-    exec_compatible_with = [
-        "@platforms//os:osx",  # yep, "osx" not "darwin"
-        "@platforms//cpu:aarch64",  # not "arm64": https://github.com/bazelbuild/platforms/pull/67
-    ],
-    target_compatible_with = [
-        "@platforms//os:osx",
-        "@platforms//cpu:aarch64",
-    ],
 
-    # matches `yq_toolchain( name = "yq_darwin_amd64", ...` in this file
-    toolchain = ":yq_darwin_arm64",
-    toolchain_type = ":toolchain_type",  # `toolchain_type(...)` above
-)
+[
+    toolchain(
+        name = "{}_toolchain".format(k),
+        exec_compatible_with = [
+            "@platforms//os:{}".format(v["os"]),
+            "@platforms//cpu:{}".format(v["cpu"]),
+        ],
+        target_compatible_with = [
+            "@platforms//os:{}".format(v["os"]),
+            "@platforms//cpu:{}".format(v["cpu"]),
+        ],
+        toolchain = ":{}".format(k),  # yq_toolchain(name=k) matches YQ.keys()
+        toolchain_type = ":toolchain_type",  # `toolchain_type(...)` above
+    )
+    for k, v in YQ.items()
+]

--- a/toolchains/yq/attachments.json
+++ b/toolchains/yq/attachments.json
@@ -1,0 +1,101 @@
+{
+  "yq_darwin_amd64": {
+    "cpu": "x86_64",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "osx",
+    "sha256": "29358dc1322b00dd7b117ddb51dc2004130547c14478aeb369b68c2546cdcea8",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_darwin_amd64.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_darwin_arm64": {
+    "cpu": "aarch64",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "osx",
+    "sha256": "6f11297e0d952749e42af19d8809700e15692acc505259216f34b19a8291760e",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_darwin_arm64.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_freebsd_386": {
+    "cpu": "i386",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "freebsd",
+    "sha256": "eb0dd1b47b4a4d7179c05f4a3b4aee9b48beffc268eb218ba3e8fea99d9a3798",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_freebsd_386.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_freebsd_amd64": {
+    "cpu": "x86_64",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "freebsd",
+    "sha256": "ea4889205b9f05534e72f0a6e4afd21ca390750552f89f480c39a38880d80306",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_freebsd_amd64.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_freebsd_arm": {
+    "cpu": "arm",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "freebsd",
+    "sha256": "686340227cd93e252c986728759cf0616501619b9a540adaf6266adc93c83f7f",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_freebsd_arm.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_linux_386": {
+    "cpu": "i386",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "linux",
+    "sha256": "b14179d6f06cafe0bbe116b33887da258b01deafa5849c2e5e42695675d03749",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_386.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_linux_amd64": {
+    "cpu": "x86_64",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "linux",
+    "sha256": "df8b1ea3ebd84bac31691e5b77b87c798f64c845370593e56603b9892cea3e1c",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_linux_arm": {
+    "cpu": "arm",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "linux",
+    "sha256": "e6fed1f09db1a418b0c9d23e9ec287ee34364935df01ad213ef9ed40abcf721c",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_arm.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_linux_arm64": {
+    "cpu": "aarch64",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "linux",
+    "sha256": "e43d788ca14c9bd949ed1c828d6073a6b42d8c78c9e454095699b1a1e844abf2",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_arm64.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_openbsd_amd64": {
+    "cpu": "x86_64",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "openbsd",
+    "sha256": "ced7fdd39a93b257a9229356dd27861e56b333888369e59b97e3e0b04a89c634",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_openbsd_amd64.tar.gz",
+    "version": "v4.34.1"
+  },
+  "yq_windows_amd64": {
+    "cpu": "x86_64",
+    "datasource": "github-release-attachments",
+    "depname": "mikefarah/yq",
+    "os": "windows",
+    "sha256": "d6bbed20ab1e94a3fffc964e8719efcc16659f78cb113808d9c9786db5dde261",
+    "url": "https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_windows_amd64.zip",
+    "version": "v4.34.1"
+  }
+}


### PR DESCRIPTION
This PR converts the boilerplate `toolchain` and `http_archive` calls into lists driven by a single JSON file.  There's some virtual external resources used as transforms from JSON to Bazel-starlark-that-looks-like-json which gives us:
 - still pre-defined not-dynamic-queries static tool definitions with checksums
 - doesn't break cache
 - updates are done intentionally, not with a mutable `latest` tag/query
 - fairly concise