### PR TITLE
feat: Automated Updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "enabled": true,
+      "matchManagers": [
+        "bazel"
+      ]
+    },
+    {
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["attachments.json$"],
+      "matchStrings": [
+          "\"cpu\": \"(.*)\",\\s    \"datasource\": \"(?<datasource>.*?)\",\\s    \"depname\": \"(?<depName>.*?)\",\\s    \"os\": \"(.*)\",\\s    \"sha256\": \"(?<currentDigest>.*?)\",\\s    \"url\": \"(?<currentUrl>.*?)\",\\s    \"version\": \"(?<currentValue>.*?)\""
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    }
+  ],
+  "reviewers": [ "@chickenandpork" ]
+}


### PR DESCRIPTION
This PR delegates the updates of versions and sha256 of the release attachments into the noted JSON file.

I mean, why not?  Laziness pays off immediately...

Caveats:
 - the JSON file is sorted.  `jq -S . attachments.json`
 - the regex mentions key/value pairs for multiple lines and is sensitive to whitespace.  `jq -S .` is your friend.
 - seriously, break the sorting, break the whitespace, the regex falls apart, silently.
 - silently.  Not knowing is worse