### PR TITLE
document detail

### DIFF
--- a/.github/cspell.yaml
+++ b/.github/cspell.yaml
@@ -1,0 +1,34 @@
+---
+# cSpell Settings
+
+# Done in YAML rather than JSON because -- like XML -- there is a cleary-documented way to write
+# comments that don't hit-or-miss fail on some parsers.  We're miles ahead of XML with JSON;
+# someday, JSON will even reach parity!
+
+version: "0.2"
+
+# flagWords - list of words to be always considered incorrect
+# This is useful for offensive words and common spelling errors.
+# For example "hte" should be "the"
+flagWords:
+  - hte
+
+language: en
+
+# words - list of words to be always considered correct: an Allowlist per-se
+words:
+  - aarch64
+  - allanc
+  - bazel
+  - bazelisk
+  - bazelrc
+  - brewfiles
+  - chickenandpork
+  - fwew
+  - ibazel
+  - opentofu
+  - skylib
+  - struct
+  - techdebt
+  - unittesting
+  - yqinfo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,12 @@ repos:
     hooks:
       - id: check-github-workflows
       - id: check-renovate
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v7.2.0
+    hooks:
+      - id: cspell
+        # a local allowlist of dictionary words in .github/cspell.yaml.  This can get comical --
+        # adding new words in every PR -- but the cost/benefit balance may avoid some embarassing
+        # typos
+        args: [ '--config', '.github/cspell.yaml' ]
+        types: [file, markdown]


### PR DESCRIPTION
This PR adds a note suggestion how tools similar to [chickenandbazel](https://github.com/chickenandpork/chickenandbazel/pull/48) -- except privately in an employer's org -- benefit as well form a single structured record of tool, version, signature in other parts such as sanity-checks, documentation, and other templates.  by leveraging the update of the tool to also update the metadata that's used elsewhere, we keep a clean atomic delta for tools and docs and scripts.  ... but if you don't need that, then definitely don't use this method.